### PR TITLE
Generates a single key pair locally and then distributes said key to …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
-  
+local_ssl_key_directory: /tmp
+local_ssl_key_private_file: keymaster-private.key
+local_ssl_key_public_file: keymaster-public.key
 ssl_key_directory: /opt/keys/claw
 ssl_key_public_file: public.key
 ssl_key_private_file: private.key
-ssl_key_private_output_path: /tmp/private.key
-ssl_key_public_output_path: /tmp/public.key
+ssl_key_private_output_path: "{{ ssl_key_directory }}/{{ ssl_key_private_file }}"
+ssl_key_public_output_path: "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,14 @@
     path: "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}"
   delegate_to: 127.0.0.1
   register: "key"
+  become: no
 
 - name: Create Local JWT Key Directory
   file:
     state: directory
     path: "{{ local_ssl_key_directory }}"
   delegate_to: 127.0.0.1
+  become: no
 
 - name: Create Remote JWT Key Path
   file:
@@ -23,12 +25,14 @@
     creates: "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}"
   when: not key.stat.exists 
   delegate_to: 127.0.0.1
+  become: no
 
 - name: Create Local JWT Public Key
   command: openssl rsa -pubout -in "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}" -out "{{ local_ssl_key_directory }}/{{ local_ssl_key_public_file }}"
   args:
     creates: "{{ local_ssl_key_directory }}/{{ local_ssl_key_public_file }}"
   delegate_to: 127.0.0.1
+  become: no
 
 - name: Copy public key out
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,46 @@
 ---
 
-- name: Create JWT Key Path
+- name: Check if the private key  already exists locally
+  stat:
+    path: "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}"
+  delegate_to: 127.0.0.1
+  register: "key"
+
+- name: Create Local JWT Key Directory
+  file:
+    state: directory
+    path: "{{ local_ssl_key_directory }}"
+  delegate_to: 127.0.0.1
+
+- name: Create Remote JWT Key Path
   file:
     state: directory
     path: "{{ ssl_key_directory }}"
 
-- name: Create JWT Private Key
-  command: openssl genrsa -out "{{ ssl_key_directory }}/{{ ssl_key_private_file }}" 2048
+- name: Create Local JWT Private Key
+  command: openssl genrsa -out "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}" 2048
   args:
-    creates: "{{ ssl_key_directory }}/{{ ssl_key_private_file }}"
+    creates: "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}"
+  when: not key.stat.exists 
+  delegate_to: 127.0.0.1
 
-- name: Create JWT Public Key
-  command: openssl rsa -pubout -in "{{ ssl_key_directory }}/{{ ssl_key_private_file }}" -out "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+- name: Create Local JWT Public Key
+  command: openssl rsa -pubout -in "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}" -out "{{ local_ssl_key_directory }}/{{ local_ssl_key_public_file }}"
   args:
-    creates: "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+    creates: "{{ local_ssl_key_directory }}/{{ local_ssl_key_public_file }}"
+  delegate_to: 127.0.0.1
 
 - name: Copy public key out
   copy:
-    src: "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+    src: "{{ local_ssl_key_directory }}/{{ local_ssl_key_public_file }}"
     dest: "{{ ssl_key_public_output_path }}"
     mode: 0644
-    remote_src: yes
+    remote_src: no
+  
     
 - name: Copy private key out
   copy:
-    src: "{{ ssl_key_directory }}/{{ ssl_key_private_file }}"
+    src: "{{ local_ssl_key_directory }}/{{ local_ssl_key_private_file }}"
     dest: "{{ ssl_key_private_output_path }}"
     mode: 0644
-    remote_src: true
+    remote_src: no


### PR DESCRIPTION
…all hosts

thus ensuring that all hosts share the same key.

**GitHub Issue**: N/A

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Previously, this role was generating a key pair on the remote host it was run on.  That was fine when we could assume one host.  In a distributed islandora 8 the keys must match across hosts.   This update ensures that the key is generated once locally and distributed on all subsequent invocations.  One additional feature is that you can supply your own private key if you don't want ansible to generate one overriding the following variables: 

local_ssl_key_directory
local_ssl_key_private_file

# How should this be tested?

If this is working correctly, the keys on all your hosts should match. 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
